### PR TITLE
googleClosure parse error fix

### DIFF
--- a/dist/jquery.smartselect.js
+++ b/dist/jquery.smartselect.js
@@ -3869,19 +3869,19 @@
 
                 this._debug('_setSelectLabel');
 
-                var long;
+                var longString;
                 if (typeof txt === 'string') {
                     var text = txt;
-                    long = txt;
+                    longString = txt;
                 } else {
                     // default text
                     var text = this.x.selectLabel;
-                    long = text;
+                    longString = text;
 
                     // selected option text
                     var labels = this.getSelectedPairs().text;
                     if (labels.length) {
-                        long = labels.join(',');
+                        longString = labels.join(',');
                         if (this.o.showSelectedCallback) {
                             text = this.o.showSelectedCallback.call(this, labels);
                         } else {
@@ -3897,7 +3897,7 @@
                 // set it
                 this.$select
                     .find('.' + this.m.label)
-                    .attr('title', long)
+                    .attr('title', longString)
                     .html(text);
             }
 


### PR DESCRIPTION
googleClosure compiler has error:

jquery.smartselect.js:3872: ERROR - Parse error. identifier is a reserved word
                var long;
                    ^
jquery.smartselect.js:3875: ERROR - Parse error. identifier is a reserved word
                    long = txt;
                    ^
jquery.smartselect.js:3879: ERROR - Parse error. identifier is a reserved word
                    long = text;
                    ^
jquery.smartselect.js:3884: ERROR - Parse error. identifier is a reserved word
                        long = labels.join(',');
                        ^
jquery.smartselect.js:3900: ERROR - Parse error. identifier is a reserved word
                    .attr('title', long)

This commit fix for it
